### PR TITLE
INFOSEC-4893: Update grove to use cursor instead of timestamp

### DIFF
--- a/grove/connectors/onepassword/api.py
+++ b/grove/connectors/onepassword/api.py
@@ -90,7 +90,9 @@ class Client:
         :param cursor: Cursor to use when fetching results. Supersedes other parameters.
         :param start_time: The ISO Format timestamp to query logs since.
 
-        :return: AuditLogEntries object containing a pagination cursor, and log entries.
+        :return:
+            - AuditLogEntries object containing a pagination cursor, and log entries.
+            - Bool object indicates whether there are more events to process.
         """
         url = f"https://{self.hostname}/api/v2/{event_type}"
 
@@ -110,7 +112,7 @@ class Client:
             )
 
         cursor = result.body.get("cursor")
-        has_more = result.body.get("has_more") in (True, "true", "True")
+        has_more = result.body.get("has_more") in [True]
 
         # Return the cursor and the results to allow the caller to page as required.
         return (
@@ -128,7 +130,9 @@ class Client:
         :param cursor: Cursor to use when fetching results. Supersedes other parameters.
         :param start_time: The ISO Format timestamp to query logs since.
 
-        :return: AuditLogEntries object containing a pagination cursor, and log entries.
+        :return:
+            - AuditLogEntries object containing a pagination cursor, and log entries.
+            - Bool object indicates whether there are more events to process.
         """
         events, has_more = self.get_events(
             event_type="signinattempts", cursor=cursor, start_time=start_time
@@ -137,8 +141,8 @@ class Client:
         # when saving the pointer, Grove looks for the pointer value within an entry
         # rather than externally to it. 1Password's pointer is external to the entry. To
         # get around this, copy internally.
-        for entry in events.entries:
-            entry["cursor"] = events.cursor
+        if len(events.entries) > 0:
+            events.entries[-1]["cursor"] = events.cursor
 
         return events, has_more
 
@@ -152,7 +156,9 @@ class Client:
         :param cursor: Cursor to use when fetching results. Supersedes other parameters.
         :param start_time: The ISO Format timestamp to query logs since.
 
-        :return: AuditLogEntries object containing a pagination cursor, and log entries.
+        :return:
+            - AuditLogEntries object containing a pagination cursor, and log entries.
+            - Bool object indicates whether there are more events to process.
         """
         events, has_more = self.get_events(
             event_type="itemusages", cursor=cursor, start_time=start_time
@@ -161,8 +167,8 @@ class Client:
         # when saving the pointer, Grove looks for the pointer value within an entry
         # rather than externally to it. 1Password's pointer is external to the entry. To
         # get around this, copy internally.
-        for entry in events.entries:
-            entry["cursor"] = events.cursor
+        if len(events.entries) > 0:
+            events.entries[-1]["cursor"] = events.cursor
 
         return events, has_more
 
@@ -176,7 +182,9 @@ class Client:
         :param cursor: Cursor to use when fetching results. Supersedes other parameters.
         :param start_time: The ISO Format timestamp to query logs since.
 
-        :return: AuditLogEntries object containing a pagination cursor, and log entries.
+        :return:
+            - AuditLogEntries object containing a pagination cursor, and log entries.
+            - Bool object indicates whether there are more events to process.
         """
         events, has_more = self.get_events(
             event_type="auditevents", cursor=cursor, start_time=start_time
@@ -185,7 +193,7 @@ class Client:
         # when saving the pointer, Grove looks for the pointer value within an entry
         # rather than externally to it. 1Password's pointer is external to the entry. To
         # get around this, copy internally.
-        for entry in events.entries:
-            entry["cursor"] = events.cursor
+        if len(events.entries) > 0:
+            events.entries[-1]["cursor"] = events.cursor
 
         return events, has_more

--- a/grove/connectors/onepassword/api.py
+++ b/grove/connectors/onepassword/api.py
@@ -92,7 +92,7 @@ class Client:
 
         :return:
             - AuditLogEntries object containing a pagination cursor, and log entries.
-            - Bool object indicates whether there are more events to process.
+            - Boolean indicating whether there are more events to process.
         """
         url = f"https://{self.hostname}/api/v2/{event_type}"
 
@@ -112,7 +112,7 @@ class Client:
             )
 
         cursor = result.body.get("cursor")
-        has_more = result.body.get("has_more") in [True]
+        has_more = result.body.get("has_more") is True
 
         # Return the cursor and the results to allow the caller to page as required.
         return (
@@ -132,7 +132,7 @@ class Client:
 
         :return:
             - AuditLogEntries object containing a pagination cursor, and log entries.
-            - Bool object indicates whether there are more events to process.
+            - Boolean indicating whether there are more events to process.
         """
         events, has_more = self.get_events(
             event_type="signinattempts", cursor=cursor, start_time=start_time
@@ -158,7 +158,7 @@ class Client:
 
         :return:
             - AuditLogEntries object containing a pagination cursor, and log entries.
-            - Bool object indicates whether there are more events to process.
+            - Boolean indicating whether there are more events to process.
         """
         events, has_more = self.get_events(
             event_type="itemusages", cursor=cursor, start_time=start_time
@@ -184,7 +184,7 @@ class Client:
 
         :return:
             - AuditLogEntries object containing a pagination cursor, and log entries.
-            - Bool object indicates whether there are more events to process.
+            - Boolean indicating whether there are more events to process.
         """
         events, has_more = self.get_events(
             event_type="auditevents", cursor=cursor, start_time=start_time

--- a/grove/connectors/onepassword/api.py
+++ b/grove/connectors/onepassword/api.py
@@ -96,7 +96,7 @@ class Client:
 
         # Use the cursor URL if set, otherwise construct the initial query.
         if cursor is not None:
-            self.logger.info(
+            self.logger.debug(
                 "Collecting next page with provided cursor",
                 extra={"cursor": cursor},
             )
@@ -134,6 +134,9 @@ class Client:
             event_type="signinattempts", cursor=cursor, start_time=start_time
         )
 
+        # when saving the pointer, Grove looks for the pointer value within an entry
+        # rather than externally to it. 1Password's pointer is external to the entry. To
+        # get around this, copy internally.
         for entry in events.entries:
             entry["cursor"] = events.cursor
 
@@ -155,6 +158,9 @@ class Client:
             event_type="itemusages", cursor=cursor, start_time=start_time
         )
 
+        # when saving the pointer, Grove looks for the pointer value within an entry
+        # rather than externally to it. 1Password's pointer is external to the entry. To
+        # get around this, copy internally.
         for entry in events.entries:
             entry["cursor"] = events.cursor
 
@@ -176,6 +182,9 @@ class Client:
             event_type="auditevents", cursor=cursor, start_time=start_time
         )
 
+        # when saving the pointer, Grove looks for the pointer value within an entry
+        # rather than externally to it. 1Password's pointer is external to the entry. To
+        # get around this, copy internally.
         for entry in events.entries:
             entry["cursor"] = events.cursor
 

--- a/grove/connectors/onepassword/events_itemusages.py
+++ b/grove/connectors/onepassword/events_itemusages.py
@@ -2,18 +2,15 @@
 # SPDX-License-Identifier: MPL-2.0
 
 """1Password ItemUsage event log connector for Grove."""
-
-import datetime
-
 from grove.connectors.onepassword.api import Client
 from grove.connectors import BaseConnector
 from grove.constants import CHRONOLOGICAL
-from grove.exceptions import NotFoundException
+from grove.connectors.onepassword.util import get_pointer_values
 
 
 class Connector(BaseConnector):
     CONNECTOR = "onepassword_events_itemusages"
-    POINTER_PATH = "timestamp"
+    POINTER_PATH = "cursor"
     LOG_ORDER = CHRONOLOGICAL
 
     def collect(self):
@@ -23,25 +20,24 @@ class Connector(BaseConnector):
         collections. If not, the last week of data will be collected.
         """
         client = Client(token=self.key)
-        cursor = None
 
-        # If no pointer is stored then a previous run hasn't been performed, so set the
-        # pointer to a week ago. In the case of the 1Password API this is an ISO
-        # timestamp in a field called "timestamp".
-        try:
-            _ = self.pointer
-        except NotFoundException:
-            week_ago = datetime.datetime.now() - datetime.timedelta(days=7)
-            self.pointer = (week_ago).astimezone().replace(microsecond=0).isoformat()
+        # self.pointer could start out as either a cursor or ISO timestamp depending on if this
+        # is an upgrade. That said, once we reach here, cursor will always be used as the
+        # pointer. self.pointer is also used elsewhere for content like saving to the cache.
+        cursor, start_time = get_pointer_values(self)
+        self.pointer = cursor
 
         # Get log data from the upstream API, paging as required.
         while True:
-            log = client.get_itemusages(start_time=self.pointer, cursor=cursor)
+            log, has_more = client.get_itemusages(
+                start_time=start_time,
+                cursor=cursor,
+            )
 
             # Save this batch of log entries.
             self.save(log.entries)
 
             # Check if we need to continue paging.
             cursor = log.cursor
-            if cursor is None:
+            if not has_more:
                 break

--- a/grove/connectors/onepassword/events_signinattempts.py
+++ b/grove/connectors/onepassword/events_signinattempts.py
@@ -3,17 +3,15 @@
 
 """1Password Signin Attempt event log connector for Grove."""
 
-import datetime
-
 from grove.connectors.onepassword.api import Client
 from grove.connectors import BaseConnector
 from grove.constants import CHRONOLOGICAL
-from grove.exceptions import NotFoundException
+from grove.connectors.onepassword.util import get_pointer_values
 
 
 class Connector(BaseConnector):
     CONNECTOR = "onepassword_events_signinattempts"
-    POINTER_PATH = "timestamp"
+    POINTER_PATH = "cursor"
     LOG_ORDER = CHRONOLOGICAL
 
     def collect(self):
@@ -23,25 +21,24 @@ class Connector(BaseConnector):
         collections. If not, the last week of data will be collected.
         """
         client = Client(token=self.key)
-        cursor = None
 
-        # If no pointer is stored then a previous run hasn't been performed, so set the
-        # pointer to a week ago. In the case of the 1Password API this is an ISO
-        # timestamp in a field called "timestamp".
-        try:
-            _ = self.pointer
-        except NotFoundException:
-            week_ago = datetime.datetime.now() - datetime.timedelta(days=7)
-            self.pointer = (week_ago).astimezone().replace(microsecond=0).isoformat()
+        # self.pointer could start out as either a cursor or ISO timestamp depending on if this
+        # is an upgrade. That said, once we reach here, cursor will always be used as the
+        # pointer. self.pointer is also used elsewhere for content like saving to the cache.
+        cursor, start_time = get_pointer_values(self)
+        self.pointer = cursor
 
         # Get log data from the upstream API, paging as required.
         while True:
-            log = client.get_signinattempts(start_time=self.pointer, cursor=cursor)
+            log, has_more = client.get_signinattempts(
+                start_time=start_time,
+                cursor=cursor,
+            )
 
             # Save this batch of log entries.
             self.save(log.entries)
 
             # Check if we need to continue paging.
             cursor = log.cursor
-            if cursor is None:
+            if not has_more:
                 break

--- a/grove/connectors/onepassword/util.py
+++ b/grove/connectors/onepassword/util.py
@@ -1,0 +1,38 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+from datetime import datetime, timedelta
+from grove.exceptions import NotFoundException
+
+
+def get_pointer_values(connector):
+    """Gets the start_time and cursor values to use for queries.
+
+    Checks to see if a previous pointer has been set. If so, it checks to see if it's
+    a date (pointer was previously set in cache and not upgraded) and if not assumes
+    it's a cursor. If the pointer is not found, it sets a date of 7 days ago as a starting
+    point"""
+
+    try:
+        _ = connector.pointer
+        if not connector.pointer:
+            raise NotFoundException
+    except NotFoundException:
+        week_ago = datetime.now() - timedelta(days=7)
+        start_time = (week_ago).astimezone().replace(microsecond=0).isoformat()
+        return None, start_time
+
+    cursor = ""
+    start_time = ""
+
+    # originally, we used the timestamp for the pointer. Check to see we have a timestamp
+    # for backwards compatibility. Otherwise interpet it as a cursor.
+    try:
+        datetime.fromisoformat(connector.pointer)
+    except ValueError:
+        connector.logger.info("Pointer is already a cursor")
+        cursor = connector.pointer
+    else:
+        connector.logger.info("Pointer is a timestamp.")
+        start_time = connector.pointer
+    return cursor, start_time

--- a/grove/connectors/onepassword/util.py
+++ b/grove/connectors/onepassword/util.py
@@ -14,8 +14,12 @@ def get_pointer_values(connector):
     point
 
     :param connector: Instance of the 1Password connector (we use logger and pointer).
-    :return: start_time - either initial time or parsed time parsed from pointer
-    :return: cursor - opaque string representing an index into 1Password's event stream
+    :return: A tuple containing (cursor, start_time).
+        - cursor - opaque string representing an index into 1Password's event stream. If
+        we can't parse the cached pointer as a time, we assume it's a cursor. Returns an
+        empty string if start_time is present.
+        - start_time - Time parsed from cached pointer. Returns an empty string if
+        cursor is present. If there's no cached pointer, default to 7 days ago.
     """
 
     try:

--- a/tests/test_connectors_onepassword_events_audit.py
+++ b/tests/test_connectors_onepassword_events_audit.py
@@ -91,7 +91,9 @@ class OnePasswordItemUsageEventTestCase(unittest.TestCase):
         # Ensure only a single value is returned, and the pointer is properly set.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 3)
-        self.assertEqual(self.connector.pointer, "2023-03-15T16:50:50-03:00")
+        self.assertEqual(
+            self.connector.pointer, "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK"
+        )
 
     @responses.activate
     def test_collect_pagination(self):
@@ -131,4 +133,6 @@ class OnePasswordItemUsageEventTestCase(unittest.TestCase):
         # Ensure only a single value is returned, and the pointer is properly set.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 1)
-        self.assertEqual(self.connector.pointer, "2023-03-15T16:33:50-03:00")
+        self.assertEqual(
+            self.connector.pointer, "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK"
+        )

--- a/tests/test_connectors_onepassword_events_itemusages.py
+++ b/tests/test_connectors_onepassword_events_itemusages.py
@@ -91,7 +91,9 @@ class OnePasswordItemUsageEventTestCase(unittest.TestCase):
         # Ensure only a single value is returned, and the pointer is properly set.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 3)
-        self.assertEqual(self.connector.pointer, "2020-06-11T16:42:55-03:00")
+        self.assertEqual(
+            self.connector.pointer, "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK"
+        )
 
     @responses.activate
     def test_collect_pagination(self):
@@ -131,4 +133,6 @@ class OnePasswordItemUsageEventTestCase(unittest.TestCase):
         # Ensure only a single value is returned, and the pointer is properly set.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 2)
-        self.assertEqual(self.connector.pointer, "2020-06-11T16:52:55-03:00")
+        self.assertEqual(
+            self.connector.pointer, "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IL"
+        )

--- a/tests/test_connectors_onepassword_events_signinattempts.py
+++ b/tests/test_connectors_onepassword_events_signinattempts.py
@@ -91,7 +91,9 @@ class OnePasswordSigninEventTestCase(unittest.TestCase):
         # Ensure only a single value is returned, and the pointer is properly set.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 2)
-        self.assertEqual(self.connector.pointer, "2021-03-01T16:42:50-03:00")
+        self.assertEqual(
+            self.connector.pointer, "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK"
+        )
 
     @responses.activate
     def test_collect_pagination(self):
@@ -131,4 +133,6 @@ class OnePasswordSigninEventTestCase(unittest.TestCase):
         # Ensure only a single value is returned, and the pointer is properly set.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 2)
-        self.assertEqual(self.connector.pointer, "2021-03-01T16:42:50-03:00")
+        self.assertEqual(
+            self.connector.pointer, "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK"
+        )

--- a/tests/test_connectors_onepassword_util.py
+++ b/tests/test_connectors_onepassword_util.py
@@ -1,0 +1,85 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements unit tests for the 1Password get_pointer_values function. This is a common
+function that is used to get the proper cursor/timestamp to use."""
+import os
+import unittest
+from datetime import datetime, timedelta
+
+from grove.connectors.onepassword.events_itemusages import Connector
+from grove.connectors.onepassword.util import get_pointer_values
+from grove.models import ConnectorConfig
+
+
+class OnePasswordGetPointerValuesTestCase(unittest.TestCase):
+    """Implements unit tests for the 1Password get_pointer_values function."""
+
+    def setUp(self):
+        """Ensure the application is setup for testing."""
+        self.dir = os.path.dirname(os.path.abspath(__file__))
+        self.connector = Connector(
+            config=ConnectorConfig(
+                identity="examplecorp",
+                key="0123456789",
+                name="examplecorp",
+                connector="test",
+            ),
+            context={
+                "runtime": "test_harness",
+                "runtime_id": "NA",
+            },
+        )
+
+    def test_check_timestamp_returns_timestamp(self):
+        """Tests what happens if get_pointer values is passed a timestamp for a pointer.
+        We expect to detect the timestamp and return that with an empty cursor.
+
+        :param self: Instance of the 1Password connector
+        """
+        current_time = datetime.now().isoformat()
+        self.connector.pointer = current_time
+        cursor, start_time = get_pointer_values(self.connector)
+
+        self.assertEqual(cursor, "")
+        self.assertEqual(start_time, current_time)
+
+    def test_check_cursor_returns_cursor(self):
+        """Tests what happens if get_pointer values is passed a cursor for a pointer.
+        We expect to detect the cursor and return that with an empty timestamp.
+
+        :param self: Instance of the 1Password connector
+        """
+        test_cursor = "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK"
+        self.connector.pointer = test_cursor
+        cursor, start_time = get_pointer_values(self.connector)
+
+        self.assertEqual(start_time, "")
+        self.assertEqual(cursor, test_cursor)
+
+    def test_check_empty_returns_timestamp(self):
+        """Tests what happens if get_pointer values isn't passed a pointer.
+        We expect it to detect the missing pointer and use a default time to initialize.
+
+        :param self: Instance of the 1Password connector
+        """
+        week_ago = datetime.now() - timedelta(days=7)
+        test_start_time = (week_ago).astimezone().replace(microsecond=0).isoformat()
+        cursor, start_time = get_pointer_values(self.connector)
+
+        self.assertEqual(cursor, "")
+        self.assertGreaterEqual(start_time, test_start_time)
+
+    def test_check_none_returns_timestamp(self):
+        """Tests what happens if get_pointer values is passed an empty pointer.
+        We expect it to detect the empty pointer and use a default time to initialize.
+
+        :param self: Instance of the 1Password connector
+        """
+        week_ago = datetime.now() - timedelta(days=7)
+        test_start_time = (week_ago).astimezone().replace(microsecond=0).isoformat()
+        self.connector.pointer = str()
+        cursor, start_time = get_pointer_values(self.connector)
+
+        self.assertEqual(cursor, "")
+        self.assertGreaterEqual(start_time, test_start_time)

--- a/tests/test_connectors_onepassword_util.py
+++ b/tests/test_connectors_onepassword_util.py
@@ -17,7 +17,6 @@ class OnePasswordGetPointerValuesTestCase(unittest.TestCase):
 
     def setUp(self):
         """Ensure the application is setup for testing."""
-        self.dir = os.path.dirname(os.path.abspath(__file__))
         self.connector = Connector(
             config=ConnectorConfig(
                 identity="examplecorp",
@@ -34,52 +33,32 @@ class OnePasswordGetPointerValuesTestCase(unittest.TestCase):
     def test_check_timestamp_returns_timestamp(self):
         """Tests what happens if get_pointer values is passed a timestamp for a pointer.
         We expect to detect the timestamp and return that with an empty cursor.
-
-        :param self: Instance of the 1Password connector
         """
         current_time = datetime.now().isoformat()
         self.connector.pointer = current_time
         cursor, start_time = get_pointer_values(self.connector)
 
-        self.assertEqual(cursor, "")
+        self.assertEqual(cursor, None)
         self.assertEqual(start_time, current_time)
 
     def test_check_cursor_returns_cursor(self):
         """Tests what happens if get_pointer values is passed a cursor for a pointer.
         We expect to detect the cursor and return that with an empty timestamp.
-
-        :param self: Instance of the 1Password connector
         """
         test_cursor = "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK"
         self.connector.pointer = test_cursor
         cursor, start_time = get_pointer_values(self.connector)
 
-        self.assertEqual(start_time, "")
+        self.assertEqual(start_time, None)
         self.assertEqual(cursor, test_cursor)
 
     def test_check_empty_returns_timestamp(self):
         """Tests what happens if get_pointer values isn't passed a pointer.
         We expect it to detect the missing pointer and use a default time to initialize.
-
-        :param self: Instance of the 1Password connector
         """
         week_ago = datetime.now() - timedelta(days=7)
         test_start_time = (week_ago).astimezone().replace(microsecond=0).isoformat()
         cursor, start_time = get_pointer_values(self.connector)
 
-        self.assertEqual(cursor, "")
-        self.assertGreaterEqual(start_time, test_start_time)
-
-    def test_check_none_returns_timestamp(self):
-        """Tests what happens if get_pointer values is passed an empty pointer.
-        We expect it to detect the empty pointer and use a default time to initialize.
-
-        :param self: Instance of the 1Password connector
-        """
-        week_ago = datetime.now() - timedelta(days=7)
-        test_start_time = (week_ago).astimezone().replace(microsecond=0).isoformat()
-        self.connector.pointer = str()
-        cursor, start_time = get_pointer_values(self.connector)
-
-        self.assertEqual(cursor, "")
+        self.assertEqual(cursor, None)
         self.assertGreaterEqual(start_time, test_start_time)


### PR DESCRIPTION
This updates grove to use the cursor for 1Password  instead of timestamp as per their API (https://developer.1password.com/docs/events-api/reference/)

Upstream GitHub issue and related conversation: https://github.com/hashicorp-forge/grove/issues/64